### PR TITLE
define login shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk update && \
 
 RUN apk add shadow
 
-RUN groupadd mojolicious && useradd -m -g mojolicious mojolicious
+RUN groupadd mojolicious && useradd -m -s /bin/ash -g mojolicious mojolicious

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 A small docker image with alpine and Mojolicious
 
 I use this as a base for Glue dev environments.
+
+```bash
+# build current directory, wit latest commit as tag name
+docker build  -t reneeb/alpinemojo:$(git rev-parse --short HEAD) .
+
+# run the build with the latest commit as tag name
+docker run -i -t reneeb/alpinemojo:$(git rev-parse --short HEAD)
+```


### PR DESCRIPTION
`/bin/bash` was defined for user `mojolicious` in `/etc/passwd`.
But `/bin/bash` does not exists on the system.
Changed to `/bin/ash` 