### PR TITLE
define correct login shell for app user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk update && \
 
 RUN apk add shadow
 
-RUN groupadd mojolicious && useradd -m -g mojolicious mojolicious
+RUN groupadd mojolicious && useradd -m -s /bin/ash -g mojolicious mojolicious


### PR DESCRIPTION
`/bin/bash` was defined for user `mojolicious` in `/etc/passwd`.
But `/bin/bash` does not exists on the system.
Changed to `/bin/ash` 